### PR TITLE
fix(wfx_test_agent): correct readout of driver version

### DIFF
--- a/test-feature/wfx_test_agent
+++ b/test-feature/wfx_test_agent
@@ -49,7 +49,11 @@ case "$1" in
         exit 0
         ;;
     read_driver_version)
-        echo "$(modinfo wfx | grep ^version: | cut -d _ -f 2 )"
+        if [ "$(modinfo -F version wfx)" ]; then
+          echo "$(modinfo -F version wfx) (downstream)"
+        else
+          echo "$(modinfo -F vermagic wfx) (upstream)"
+        fi
         exit 0
         ;;
     log_message)


### PR DESCRIPTION
The current upstream wfx driver does not use the `MODULE_VERSION` variable anymore to set the version (as opposed to the legacy code https://github.com/SiliconLabs/wfx-linux-driver/blob/15a127a0d112ce91729d755fa53b4e835a3a4acb/main.c#L46). This makes the `wfx_test_agent read_driver_version` command fail. Correct the command to use the kernel-generated `vermagic` field instead.