### PR TITLE
Support TLV format for the wfx_test_agent

### DIFF
--- a/test-feature/wfx_test_agent
+++ b/test-feature/wfx_test_agent
@@ -30,9 +30,16 @@ case "$1" in
         exit 0
         ;;
     write_test_data)
+        if [ -z "$2" ]; then
+          echo "$USAGE"
+          exit 1
+        fi
+
         test_data_input=$(ls /sys/kernel/debug/ieee80211/phy*/wfx/send_pds)
-        echo ${2} > ${test_data_input}
-        echo "'${2}' sent to ${test_data_input}"
+        pds_data="$2"
+        printf "$pds_data" > "$test_data_input"
+        echo "'$pds_data' sent to ${test_data_input}"
+
         exit 0
         ;;
     read_rx_stats)

--- a/test-feature/wfx_test_agent
+++ b/test-feature/wfx_test_agent
@@ -25,7 +25,7 @@ case "$1" in
         exit 0
         ;;
     read_agent_version)
-        echo "1.1.0"
+        echo "1.2.0"
         exit 0
         ;;
     write_test_data)

--- a/test-feature/wfx_test_agent
+++ b/test-feature/wfx_test_agent
@@ -7,13 +7,12 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-USAGE="Usage: $(basename $0) OPTION
+USAGE="Usage: $(basename $0) [-h|--help] COMMAND
 
 Rf Tests
 
-Options:
-  --help                display this message
-  write_test_data       write test data to debugfs
+Commands:
+  write_test_data DATA  write test data to debugfs
   read_rx_stats         read rx_stats from debugfs
   read_tx_info          read tx_power_loop from debugfs
   read_fw_version       return current firmware version
@@ -21,7 +20,7 @@ Options:
 "
 
 case "$1" in
-    --help)
+    -h|--help)
         echo "$USAGE"
         exit 0
         ;;
@@ -71,8 +70,11 @@ case "$1" in
         exit 0
         ;;
     *)
-        echo "ERROR: unknown $(basename $0) option $1" >&2
-        echo "$USAGE" >&2
+        if [ -z "$1" ]; then
+          echo "$USAGE"
+        else
+          echo "ERROR: unknown $(basename $0) command '$1'" >&2
+        fi
         exit 1
         ;;
 esac


### PR DESCRIPTION
The `write_test_data` command can only send string-formatted text to the driver, that is, PDS configuration data in legacy format. To support PDS data in the TLV format (required by the upstream driver), allow escape sequences (such as hex values from the PDS header) to be correctly interpreted.